### PR TITLE
Missing Close Button in Authentication Form

### DIFF
--- a/frontend/src/Components/Auth.jsx
+++ b/frontend/src/Components/Auth.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from "react";
 import { useNavigate, useLocation, Link } from "react-router-dom";
 import { AiFillThunderbolt } from "react-icons/ai";
 import { FaGoogle } from "react-icons/fa"; // Import Google icon
+import { IoClose } from "react-icons/io5";
 import { supabase } from "../supabaseClient";
 
 const Auth = () => {
@@ -125,7 +126,14 @@ const Auth = () => {
               : "Start your fitness journey today"}
           </p>
         </div>
-        <div className="w-full max-w-md bg-white/10 backdrop-blur-md rounded-2xl shadow-2xl p-8 text-white">
+        <div className="relative w-full max-w-md bg-white/10 backdrop-blur-md rounded-2xl shadow-2xl p-8 text-white">
+          <button
+            onClick={() => navigate("/")}
+            aria-label="Close"
+            className="absolute top-4 right-4 text-gray-400 hover:text-white transition-colors duration-200"
+          >
+            <IoClose size={24} />
+          </button>
           <form onSubmit={handleSubmit} className="space-y-6">
             {!isLogin && (
               <div>


### PR DESCRIPTION
### Problem
- Users cannot easily dismiss the sign-in/sign-up form.
- Relying on the browser back button is unintuitive, especially on mobile.

<img width="1410" height="880" alt="image" src="https://github.com/user-attachments/assets/58a62c53-b504-49ee-8eaa-82ab65220256" />
<img width="1431" height="895" alt="image" src="https://github.com/user-attachments/assets/dccda6a6-7c34-4ca4-aa2a-a61b5a2f072e" />


### Solution
- Added a close (X) button at the top-right corner of the form.
- Clicking the button redirects to the home page.
- Accessible: supports keyboard navigation and screen readers.
- Styled minimally to blend with the form UI.

### Expected Outcome
- Users can quickly close the auth form with a single click/tap.
- Improved usability and navigation experience.