### PR TITLE
Add Scroll-to-Top Button

### DIFF
--- a/frontend/src/Components/PageFooter.jsx
+++ b/frontend/src/Components/PageFooter.jsx
@@ -1,7 +1,29 @@
-import React from "react";
-import { FaTwitter, FaGithub, FaLinkedin } from "react-icons/fa";
+import React , { useState, useEffect }from "react";
+import { FaTwitter, FaGithub, FaLinkedin,FaArrowUp } from "react-icons/fa";
 
 const PageFooter = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  // Show button when user scrolls down
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.scrollY > 300) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+    window.addEventListener("scroll", toggleVisibility);
+    return () => window.removeEventListener("scroll", toggleVisibility);
+  }, []);
+
+  // Scroll to top function
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
   const socialLinks = [
     { icon: <FaGithub />, href: "https://github.com/bhavishyaPlawat/ThunderLean" },
     { icon: <FaLinkedin />, href: "https://www.linkedin.com/in/bhavishya-plawat-165184303/" },
@@ -68,6 +90,16 @@ const PageFooter = () => {
           </p>
         </div>
       </div>
+
+      {/* Scroll to Top Button */}
+      {isVisible && (
+        <button
+          onClick={scrollToTop}
+          className="fixed bottom-6 right-6 p-3 rounded-full bg-blue-600 text-white shadow-lg hover:bg-blue-700 transition-colors"
+        >
+          <FaArrowUp />
+        </button>
+      )}
     </footer>
   );
 };


### PR DESCRIPTION
### Description  
Currently, when users scroll down the page, there is no quick way to return to the top. This impacts usability, especially on long content pages.  

This PR introduces a **floating scroll-to-top button** that improves navigation and user experience.  

### 🔧 Changes Made  
- Added a **scroll-to-top button** that:  
  - Appears when the user scrolls down past 300px.  
  - Smoothly scrolls the page back to the top on click.  
  - Stays fixed at the bottom-right corner of the screen.  
  - Uses a minimal circular design with an upward arrow icon (`FaArrowUp`).  
  - Fully responsive and works across desktop and mobile.  

### 🎯 Expected Outcome  
- Users can quickly return to the top of the page with a single click.  
- Improved navigation and accessibility on pages with long lists of content or products.  

### ✅ Checklist  
- [x] Implemented scroll-to-top button  
- [x] Button visibility toggles based on scroll position  
- [x] Smooth scrolling enabled  
- [x] Responsive on mobile and desktop  
- [x] No UI overlap with other elements  

https://github.com/user-attachments/assets/87c7f207-d326-4282-a8fb-857a5c9d3390

